### PR TITLE
Accept all 2XX response headers as success

### DIFF
--- a/src/image-upload.js
+++ b/src/image-upload.js
@@ -92,7 +92,7 @@ export class ImageUpload {
 
 				// listen callback
 				xhr.onload = () => {
-					if (xhr.status === 200) {
+					if (xhr.status >= 200 && xhr.status < 300) {
 						callbackOK(JSON.parse(xhr.responseText), this.insert.bind(this));
 					} else {
 						callbackKO({


### PR DESCRIPTION
The API that I'm using for image upload returns `201` headers with successful responses. And that's also a valid response. So, I think this library should also accept any 2XX response statuses as successful response.

This PR includes that change.